### PR TITLE
Fast witness generation 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ serde_json = { version = "1.0", default-features = false }
 itertools = "0.11"
 prettytable = "0.10.0"
 
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
+tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
+
 [features]
 bench = []
 

--- a/rs-script/Cargo.toml
+++ b/rs-script/Cargo.toml
@@ -17,3 +17,12 @@ num-traits = "0.2"
 ndarray = "0.15.6"
 itertools = "0.13.0"
 rayon = "1.10.0"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
+tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
+concrete-ntt = { git = "https://github.com/zama-ai/concrete-ntt", features = [
+    "nightly",
+] }
+
+[features]
+sanity-check = []


### PR DESCRIPTION
## Changes
- replace naive poly mult with NTT
- add `poly_div_cyclo` and `poly_modulo_cyclo` that leverage structure of cyclotomic poly
- rewrite `poly_div` recursively using "divide-and-conquer" strategy.

## Known issue
- `concrete-ntt` native NTT plan fails for poly sizes > 2**15`

## Possible future work
- if `r1i` and `p1i` can be converted to field elements modulo some suitable `p` can apply batch multiplicative inverse (Mongomery trick) to further optimize `poly_div` (currently takes about ~80ms for` n=2**14`)